### PR TITLE
編集画面の追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/BookController.java
+++ b/src/main/java/jp/co/metateam/library/controller/BookController.java
@@ -56,12 +56,12 @@ public class BookController {
         return "book/add";
     }
 
-    // もりりゅー流
+    // もりりゅー流 登録処理
     @PostMapping("/book/add")
     public String createBook(@ModelAttribute("bookMstDto") BookMstDto bookMstDto, BindingResult result, Model model) {
 
-        boolean checkResult = bookMstService.checkbook(bookMstDto, model);
-        boolean checkIsbnResult = bookMstService.checkIsbnEntry(bookMstDto, model);
+        boolean checkResult = bookMstService.checkValidTitle(bookMstDto, model);
+        boolean checkIsbnResult = bookMstService.checkValidIsbn(bookMstDto, model);
 
         // 画面変更します
         if (checkResult || checkIsbnResult) {
@@ -74,10 +74,8 @@ public class BookController {
 
     }
 
-    // 今回からの処理ござ～る
-
+    // 今回変更分
     // 編集画面への遷移
-
     @GetMapping("/book/edit/{id}")
     public String editBook(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
         // IDに基づいて書籍データを取得する
@@ -90,9 +88,8 @@ public class BookController {
         }
 
         // 取得した書籍データを model にセット
-        // model.addAttribute("title", "書籍編集");
         model.addAttribute("bookMstDto", book); // 編集する書籍データを渡す
-        return "book/edit"; // edit.html を表示
+        return "book/edit";
     }
 
     // データを更新させましょう
@@ -103,38 +100,36 @@ public class BookController {
         // 書籍がすでに削除されていないか確認
         BookMstDto existingBook = bookMstService.findById(bookMstDto.getId());
         if (existingBook == null) {
-            // 削除済みのため、一覧にリダイレクトしつつメッセージを渡す
             redirectAttributes.addFlashAttribute("deleteMessage", "書籍はすでに削除されています。");
             return "redirect:/book/index";
         }
 
-        // 書籍名またはISBNが変更されているかチェック
-        boolean isTitleChanged = bookMstService.checkTitleChange(bookMstDto);
-        boolean isIsbnChanged = bookMstService.checkIsbnChange(bookMstDto);
-        // ✅ 変更点がない場合、ポップアップ用のメッセージを渡して編集画面に戻る
-        if (!isTitleChanged && !isIsbnChanged) {
+        // 変更点があるか確認
+        if (bookMstDto.getTitle().equals(existingBook.getTitle())
+                && bookMstDto.getIsbn().equals(existingBook.getIsbn())) {
             model.addAttribute("noChangeMessage", "変更点はありません");
-            // model.addAttribute("bookMstDto", bookMstDto);
             return "book/edit";
         }
 
         // タイトルに変更がある場合のバリデーション
-        if (isTitleChanged) {
-            boolean checkTitleResult = bookMstService.checkbook(bookMstDto, model);
-            if (checkTitleResult) {
-                return "book/edit";
-            }
+        boolean isInvalidTitle = false;
+        if (!bookMstDto.getTitle().equals(existingBook.getTitle())) {
+            isInvalidTitle = bookMstService.checkValidTitle(bookMstDto, model);
         }
         // ISBNに変更がある場合のバリデーション
-        if (isIsbnChanged) {
-            boolean checkIsbnResult = bookMstService.checkIsbnEntry(bookMstDto, model);
-            if (checkIsbnResult) {
+        if (!bookMstDto.getIsbn().equals(existingBook.getIsbn())) {
+            boolean isInvalidIsbn = bookMstService.checkValidIsbn(bookMstDto, model);
+            if (isInvalidIsbn) {
                 return "book/edit";
             }
         }
 
+        if (isInvalidTitle) {
+            return "book/edit";
+        }
+
         // 更新処理を実行
-        bookMstService.update(bookMstDto);
+        bookMstService.save(bookMstDto);
         return "redirect:/book/index"; // 更新成功後のリダイレクト
     }
 

--- a/src/main/java/jp/co/metateam/library/controller/BookController.java
+++ b/src/main/java/jp/co/metateam/library/controller/BookController.java
@@ -129,7 +129,7 @@ public class BookController {
         }
 
         // 更新処理を実行
-        bookMstService.save(bookMstDto);
+        bookMstService.update(bookMstDto);
         return "redirect:/book/index"; // 更新成功後のリダイレクト
     }
 

--- a/src/main/java/jp/co/metateam/library/controller/BookController.java
+++ b/src/main/java/jp/co/metateam/library/controller/BookController.java
@@ -8,12 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
@@ -62,7 +56,6 @@ public class BookController {
         return "book/add";
     }
 
-
     // もりりゅー流
     @PostMapping("/book/add")
     public String createBook(@ModelAttribute("bookMstDto") BookMstDto bookMstDto, BindingResult result, Model model) {
@@ -71,7 +64,7 @@ public class BookController {
         boolean checkIsbnResult = bookMstService.checkIsbnEntry(bookMstDto, model);
 
         // 画面変更します
-        if (checkResult||checkIsbnResult) {
+        if (checkResult || checkIsbnResult) {
             return "book/add"; // バリデーションエラー時、登録画面に戻す
         }
 
@@ -81,5 +74,68 @@ public class BookController {
 
     }
 
+    // 今回からの処理ござ～る
+
+    // 編集画面への遷移
+
+    @GetMapping("/book/edit/{id}")
+    public String editBook(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        // IDに基づいて書籍データを取得する
+        BookMstDto book = bookMstService.findById(id);
+
+        if (book == null) {
+            // 削除されている → 一覧画面にリダイレクトし、警告メッセージを渡す
+            redirectAttributes.addFlashAttribute("errorMessage", "指定された書籍はすでに削除されています。");
+            return "redirect:/book/index";
+        }
+
+        // 取得した書籍データを model にセット
+        model.addAttribute("title", "書籍編集");
+        model.addAttribute("bookMstDto", book); // 編集する書籍データを渡す
+        return "book/edit"; // edit.html を表示
+    }
+
+    // データを更新させましょう
+    @PostMapping("/book/edit")
+    public String editBook(@ModelAttribute("bookMstDto") BookMstDto bookMstDto, BindingResult result, Model model,
+            RedirectAttributes redirectAttributes) {
+
+        // 書籍がすでに削除されていないか確認
+        BookMstDto existingBook = bookMstService.findById(bookMstDto.getId());
+        if (existingBook == null) {
+            // 削除済みのため、一覧にリダイレクトしつつメッセージを渡す
+            redirectAttributes.addFlashAttribute("deleteMessage", "書籍はすでに削除されています。");
+            return "redirect:/book/index";
+        }
+
+        // 書籍名またはISBNが変更されているかチェック
+        boolean isTitleChanged = bookMstService.checkTitleChange(bookMstDto);
+        boolean isIsbnChanged = bookMstService.checkIsbnChange(bookMstDto);
+        // ✅ 変更点がない場合、ポップアップ用のメッセージを渡して編集画面に戻る
+        if (!isTitleChanged && !isIsbnChanged) {
+            model.addAttribute("noChangeMessage", "変更点はありません");
+            model.addAttribute("bookMstDto", bookMstDto);
+            return "book/edit";
+        }
+
+        // タイトルに変更がある場合のバリデーション
+        if (isTitleChanged) {
+            boolean checkTitleResult = bookMstService.checkbook(bookMstDto, model);
+            if (checkTitleResult) {
+                return "book/edit";
+            }
+        }
+        // ISBNに変更がある場合のバリデーション
+        if (isIsbnChanged) {
+            boolean checkIsbnResult = bookMstService.checkIsbnEntry(bookMstDto, model);
+            if (checkIsbnResult) {
+                return "book/edit";
+            }
+        }
+
+        // 更新処理を実行
+        bookMstService.update(bookMstDto);
+        return "redirect:/book/index"; // 更新成功後のリダイレクト
+    }
 
 }

--- a/src/main/java/jp/co/metateam/library/controller/BookController.java
+++ b/src/main/java/jp/co/metateam/library/controller/BookController.java
@@ -90,7 +90,7 @@ public class BookController {
         }
 
         // 取得した書籍データを model にセット
-        model.addAttribute("title", "書籍編集");
+        // model.addAttribute("title", "書籍編集");
         model.addAttribute("bookMstDto", book); // 編集する書籍データを渡す
         return "book/edit"; // edit.html を表示
     }
@@ -114,7 +114,7 @@ public class BookController {
         // ✅ 変更点がない場合、ポップアップ用のメッセージを渡して編集画面に戻る
         if (!isTitleChanged && !isIsbnChanged) {
             model.addAttribute("noChangeMessage", "変更点はありません");
-            model.addAttribute("bookMstDto", bookMstDto);
+            // model.addAttribute("bookMstDto", bookMstDto);
             return "book/edit";
         }
 

--- a/src/main/java/jp/co/metateam/library/model/BookMstDto.java
+++ b/src/main/java/jp/co/metateam/library/model/BookMstDto.java
@@ -2,8 +2,11 @@ package jp.co.metateam.library.model;
 
 import java.security.Timestamp;
 
+import org.springframework.beans.factory.annotation.Autowired;
+
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
+import jp.co.metateam.library.repository.BookMstRepository;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,13 +16,13 @@ import lombok.Setter;
 @Getter
 @Setter
 public class BookMstDto {
-    
-    private Long id; 
-    
+
+    private Long id;
+
     private String isbn;
 
     private String title;
-    
+
     private Timestamp deletedAt;
 
     private BookMst bookMst;

--- a/src/main/java/jp/co/metateam/library/service/BookMstService.java
+++ b/src/main/java/jp/co/metateam/library/service/BookMstService.java
@@ -72,7 +72,7 @@ public class BookMstService {
     @PostMapping
 
     // バリデーションチェック
-    public boolean checkbook(BookMstDto bookMstDto, Model model) {
+    public boolean checkValidTitle(BookMstDto bookMstDto, Model model) {
         String Title = bookMstDto.getTitle();
         List<String> validationTitleErrors = new ArrayList<String>();
 
@@ -92,7 +92,7 @@ public class BookMstService {
         return false;
     }
 
-    public Boolean checkIsbnEntry(BookMstDto bookMstDto, Model model) {
+    public Boolean checkValidIsbn(BookMstDto bookMstDto, Model model) {
 
         // String getIsbn = bookMstDto.getIsbn();
         // List<String> errIsbnList = new ArrayList<>();
@@ -146,61 +146,6 @@ public class BookMstService {
         dto.setTitle(entity.getTitle());
         dto.setIsbn(entity.getIsbn());
         return dto;
-    }
-
-    // ★書籍IDに基づいて既存の書籍情報を取得する共通メソッド
-    private BookMst getExistingBook(BookMstDto bookMstDto) {
-        return bookMstRepository.findById(bookMstDto.getId())
-                .orElseThrow(() -> new IllegalArgumentException("書籍が見つかりません"));
-    }
-
-    // ★タイトルが変更されたかをチェック
-    public boolean checkTitleChange(BookMstDto bookMstDto) {
-        BookMst existingBook = getExistingBook(bookMstDto);
-        return !Objects.equals(existingBook.getTitle(), bookMstDto.getTitle());
-    }
-    // ★ISBNが変更されたかをチェック
-    public boolean checkIsbnChange(BookMstDto bookMstDto) {
-        BookMst existingBook = getExistingBook(bookMstDto);
-        return !Objects.equals(existingBook.getIsbn(), bookMstDto.getIsbn());
-    }
-    
-    // // ★書籍名やISBNが変更されたかどうかをチェックします
-    // public boolean checkTitleChange(BookMstDto bookMstDto) {
-    //     // IDに基づいて既存の書籍を取得
-    //     BookMst existingBook = bookMstRepository.findById(bookMstDto.getId())
-    //             .orElseThrow(() -> new IllegalArgumentException("書籍が見つかりません"));
-    
-    //     // タイトルが変更されたかを確認
-    //     return !existingBook.getTitle().equals(bookMstDto.getTitle());
-    // }
-    
-    // public boolean checkIsbnChange(BookMstDto bookMstDto) {
-    //     // IDに基づいて既存の書籍を取得
-    //     BookMst existingBook = bookMstRepository.findById(bookMstDto.getId())
-    //             .orElseThrow(() -> new IllegalArgumentException("書籍が見つかりません"));
-    
-    //     // ISBNが変更されたかを確認
-    //     return !existingBook.getIsbn().equals(bookMstDto.getIsbn());
-    // }
-
-    // ★更新処理しまぁ～す
-    public void update(BookMstDto bookMstDto) {
-        // IDがnullであれば例外
-        if (bookMstDto.getId() == null) {
-            throw new IllegalArgumentException("更新対象のIDがありません");
-        }
-
-        // DBから既存データを取得（存在しなければ例外）
-        BookMst bookMst = bookMstRepository.findById(bookMstDto.getId())
-                .orElseThrow(() -> new IllegalArgumentException("指定されたIDの書籍が存在しません"));
-
-        // フィールドを更新
-        bookMst.setTitle(bookMstDto.getTitle());
-        bookMst.setIsbn(bookMstDto.getIsbn());
-
-        // 更新はsave()でOK（内部的にUPDATE文）
-        bookMstRepository.save(bookMst);
     }
 
 }

--- a/src/main/java/jp/co/metateam/library/service/BookMstService.java
+++ b/src/main/java/jp/co/metateam/library/service/BookMstService.java
@@ -19,6 +19,8 @@ import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.model.BookMstDto;
 import jp.co.metateam.library.repository.BookMstRepository;
 
+import java.util.Objects;
+
 @Service
 public class BookMstService {
 
@@ -92,24 +94,24 @@ public class BookMstService {
 
     public Boolean checkIsbnEntry(BookMstDto bookMstDto, Model model) {
 
-        //String getIsbn = bookMstDto.getIsbn();
-        //List<String> errIsbnList = new ArrayList<>();
+        // String getIsbn = bookMstDto.getIsbn();
+        // List<String> errIsbnList = new ArrayList<>();
 
-         String isbn = bookMstDto.getIsbn();
-         List<String> validationIsbnErrors = new ArrayList<String>();
-         List<BookMst> bookMst = this.bookMstRepository.selectByIsbn(isbn);
+        String isbn = bookMstDto.getIsbn();
+        List<String> validationIsbnErrors = new ArrayList<String>();
+        List<BookMst> bookMst = this.bookMstRepository.selectByIsbn(isbn);
 
         // 2. ISBNのバリデーションチェックを行うよ
         if (StringUtils.isEmpty(isbn)) {
             validationIsbnErrors.add("ISBNは必須です。");
             model.addAttribute("isbnErrors", validationIsbnErrors);
             return true;
-        } 
-        
+        }
+
         if (isbn.length() != 13) {
             validationIsbnErrors.add("ISBNは13文字で入力してください");
             model.addAttribute("isbnErrors", validationIsbnErrors);
-       }
+        }
 
         if (!isbn.matches("^[0-9]+$")) {
             validationIsbnErrors.add("ISBNは半角数字で入力してください");
@@ -119,12 +121,86 @@ public class BookMstService {
 
         if (!bookMst.isEmpty()) {
             validationIsbnErrors.add("登録されているISBNです");
-            model.addAttribute("isbnErrors",validationIsbnErrors);
-        } 
-           
+            model.addAttribute("isbnErrors", validationIsbnErrors);
+        }
+
         if (!validationIsbnErrors.isEmpty()) {
             return true;
         }
         return false;
     }
+
+    // 今回変更分
+
+    @Autowired
+    private BookMstRepository bookRepository;
+
+    public BookMstDto findById(Long id) {
+        BookMst entity = bookRepository.findById(id).orElse(null);
+        if (entity == null) {
+            return null;
+        }
+
+        BookMstDto dto = new BookMstDto();
+        dto.setId(entity.getId());
+        dto.setTitle(entity.getTitle());
+        dto.setIsbn(entity.getIsbn());
+        return dto;
+    }
+
+    // ★書籍IDに基づいて既存の書籍情報を取得する共通メソッド
+    private BookMst getExistingBook(BookMstDto bookMstDto) {
+        return bookMstRepository.findById(bookMstDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("書籍が見つかりません"));
+    }
+
+    // ★タイトルが変更されたかをチェック
+    public boolean checkTitleChange(BookMstDto bookMstDto) {
+        BookMst existingBook = getExistingBook(bookMstDto);
+        return !Objects.equals(existingBook.getTitle(), bookMstDto.getTitle());
+    }
+    // ★ISBNが変更されたかをチェック
+    public boolean checkIsbnChange(BookMstDto bookMstDto) {
+        BookMst existingBook = getExistingBook(bookMstDto);
+        return !Objects.equals(existingBook.getIsbn(), bookMstDto.getIsbn());
+    }
+    
+    // // ★書籍名やISBNが変更されたかどうかをチェックします
+    // public boolean checkTitleChange(BookMstDto bookMstDto) {
+    //     // IDに基づいて既存の書籍を取得
+    //     BookMst existingBook = bookMstRepository.findById(bookMstDto.getId())
+    //             .orElseThrow(() -> new IllegalArgumentException("書籍が見つかりません"));
+    
+    //     // タイトルが変更されたかを確認
+    //     return !existingBook.getTitle().equals(bookMstDto.getTitle());
+    // }
+    
+    // public boolean checkIsbnChange(BookMstDto bookMstDto) {
+    //     // IDに基づいて既存の書籍を取得
+    //     BookMst existingBook = bookMstRepository.findById(bookMstDto.getId())
+    //             .orElseThrow(() -> new IllegalArgumentException("書籍が見つかりません"));
+    
+    //     // ISBNが変更されたかを確認
+    //     return !existingBook.getIsbn().equals(bookMstDto.getIsbn());
+    // }
+
+    // ★更新処理しまぁ～す
+    public void update(BookMstDto bookMstDto) {
+        // IDがnullであれば例外
+        if (bookMstDto.getId() == null) {
+            throw new IllegalArgumentException("更新対象のIDがありません");
+        }
+
+        // DBから既存データを取得（存在しなければ例外）
+        BookMst bookMst = bookMstRepository.findById(bookMstDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("指定されたIDの書籍が存在しません"));
+
+        // フィールドを更新
+        bookMst.setTitle(bookMstDto.getTitle());
+        bookMst.setIsbn(bookMstDto.getIsbn());
+
+        // 更新はsave()でOK（内部的にUPDATE文）
+        bookMstRepository.save(bookMst);
+    }
+
 }

--- a/src/main/java/jp/co/metateam/library/service/BookMstService.java
+++ b/src/main/java/jp/co/metateam/library/service/BookMstService.java
@@ -94,9 +94,6 @@ public class BookMstService {
 
     public Boolean checkValidIsbn(BookMstDto bookMstDto, Model model) {
 
-        // String getIsbn = bookMstDto.getIsbn();
-        // List<String> errIsbnList = new ArrayList<>();
-
         String isbn = bookMstDto.getIsbn();
         List<String> validationIsbnErrors = new ArrayList<String>();
         List<BookMst> bookMst = this.bookMstRepository.selectByIsbn(isbn);
@@ -146,6 +143,21 @@ public class BookMstService {
         dto.setTitle(entity.getTitle());
         dto.setIsbn(entity.getIsbn());
         return dto;
+    }
+
+    // ★更新処理
+    public void update(BookMstDto bookMstDto) {
+        
+        // DBから既存データを取得（存在しなければ例外）
+        BookMst bookMst = bookMstRepository.findById(bookMstDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("指定されたIDの書籍が存在しません"));
+
+        // フィールドを更新
+        bookMst.setTitle(bookMstDto.getTitle());
+        bookMst.setIsbn(bookMstDto.getIsbn());
+
+        // 更新はsave()でOK（内部的にUPDATE文）
+        bookMstRepository.save(bookMst);
     }
 
 }

--- a/src/main/resources/static/css/book/edit.css
+++ b/src/main/resources/static/css/book/edit.css
@@ -1,0 +1,132 @@
+#book_register_form {
+  font-size: 20px;
+}
+
+#book_register_form p .asterisk {
+  font-size: 14px;
+  margin-left: 5px;
+  margin-top: -5px;
+}
+
+#book_register_form .form_input {
+  display: inline-block;
+  width: 100%;
+  height: 55px;
+  border: 2px solid #D9D9D9;
+  padding: 2px 10px;
+  font-size: 20px;
+}
+
+
+#book_register_form .btn_block {
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
+}
+
+#submit_btn {
+  width: 80px;
+  height: 45px;
+  font-size: 20px;
+  background-color: #9CF2D3;
+  color: #545454;
+  border-radius: 0.5rem;
+  border: none;
+}
+
+#submit_btn:hover {
+  cursor: pointer;
+  opacity: 0.6;
+}
+
+.required-info {
+  color: red;
+  /* 赤文字 */
+  font-weight: bold;
+}
+
+.back-link {
+  position: absolute;
+  top: 200px;
+  /* ヘッダーの高さ分だけ余白を追加 */
+  right: 40px;
+  /* 右上に配置 */
+}
+
+.form-group {
+  margin-bottom: 20px;
+  /* 各入力項目間の余白 */
+}
+
+label {
+  display: block;
+  /* ラベルをブロック要素として表示 */
+  margin-bottom: 8px;
+  /* ラベルと入力欄の間に少し余白 */
+}
+
+input {
+  width: 100%;
+  /* 入力欄の幅を100%にして、フォームの幅いっぱいに表示 */
+  padding: 8px;
+  /* 入力欄の内部余白 */
+  border: 1px solid #ccc;
+  /* 入力欄の境界線 */
+  font-size: 14px;
+}
+
+.label-error-row {
+  display: flex;
+  align-items: center;
+  gap: 10px; /* ラベルとエラーメッセージの間の余白 */
+}
+
+.inline-error {
+  display: flex;
+  flex-direction: column;
+}
+
+.error-message {
+  color: red;
+  font-weight: bold;
+  font-size: 16px; /* ← ここで文字サイズを指定 */
+}
+
+/* ポップアップ */
+.popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 9999;
+  background-color: rgba(0, 0, 0, 0.5);
+  /* 背景の暗がり */
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.popup-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 10px;
+  width: 300px;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 20px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.close-btn:hover {
+  color: red;
+}

--- a/src/main/resources/static/css/book/index.css
+++ b/src/main/resources/static/css/book/index.css
@@ -1,21 +1,21 @@
 .books_table {
- width: 100%;
- text-align: left;
- border-collapse: collapse;
- border-spacing: 0;
- border-radius:10px;
+  width: 100%;
+  text-align: left;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border-radius: 10px;
 }
 
-.books_table th{
+.books_table th {
   padding: 10px;
-  background: rgba(0,0,0,0.06);
+  background: rgba(0, 0, 0, 0.06);
   padding: 13px;
   border: solid 1px #B9B9B9;
   color: #545454;
   font-size: 18px;
 }
 
-.books_table td{
+.books_table td {
   text-align: left;
   vertical-align: top;
   background: #FFFFFF;
@@ -24,76 +24,170 @@
   font-size: 20px;
 }
 
-.books_table td:nth-child(1){
+.books_table td:nth-child(1) {
   width: 40%;
 }
 
-.books_table td:nth-child(1) .book_title_contents{
+.books_table td:nth-child(1) .book_title_contents {
   display: flex;
   align-items: center;
 }
 
-.books_table td:nth-child(1) .book_title_contents span{
+.books_table td:nth-child(1) .book_title_contents span {
   display: inline-block;
-  margin-left:10px;
+  margin-left: 10px;
 }
 
-.books_table td .stockcount{
+.books_table td .stockcount {
   display: inline-block;
   width: 50px;
   text-align: center;
 }
 
-.books_table td img{
+.books_table td img {
   margin: 8px 2px 0 2px;
   height: auto;
 }
-.books_table td img:hover{
+
+.books_table td img:hover {
   cursor: pointer;
   opacity: 0.6;
 }
-.books_table td .edit_icon{
-  width:23px;
-}
-.books_table td .trash_icon{
-  width:19px;
+
+.books_table td .edit_icon {
+  width: 23px;
 }
 
-.books_table td a{
+.books_table td .trash_icon {
+  width: 19px;
+}
+
+.books_table td a {
   color: #0000EE;
 }
 
+
 .btn_block {
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
   padding-right: 80px;
-  /* 右側に80pxの余白を追加 */
   margin-top: 20px;
-  /*上側の余白*/
+  margin-right: -80px;
   margin-bottom: 30px;
 }
-.book_table th {
-  background-color: #f0f0f0; /* 薄いグレー */
-  padding: 10px;
-  text-align: left; /* 左揃え */
+
+.add-book-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center; /* ←ボタン内のアイコン＋文字を中央揃え */
+  gap: 10px;
+  padding: 14px 28px;
+  font-size: 18px;
+  background-color: #9CF2D3;
+  color: #545454;
+  border-radius: 0.5rem;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
 }
+
+.add-book-btn:hover {
+  opacity: 0.7;
+}
+
+.icon-image {
+  width: 24px;
+  height: 24px;
+}
+
+
+
+
+.book_table th {
+  background-color: #f0f0f0;
+  /* 薄いグレー */
+  padding: 10px;
+  text-align: left;
+  /* 左揃え */
+}
+
 .book_table td {
   padding: 10px;
-  text-align: left; /* 左揃え */
+  text-align: left;
+  /* 左揃え */
 }
 
 /* 折り返し機能 */
 .wrap-title {
-  max-width: 600px;        /* 表示幅の制限（任意） */
-  white-space: normal;     /* 折り返しを許可 */
-  word-break: break-word;  /* 単語の途中でも折り返し */
+  max-width: 600px;
+  /* 表示幅の制限（任意） */
+  white-space: normal;
+  /* 折り返しを許可 */
+  word-break: break-word;
+  /* 単語の途中でも折り返し */
   padding: 5px;
   /* border: 1px solid #ddd;  任意：見た目の補助 */
 }
 
 .table_title {
-  font-size: 20px;        /* フォントサイズ */
-  /* font-weight: bold;      太字 */
-  margin-bottom: 20px;    /* 下にスペース */
-  margin-left: 80px; 
-  color: #B9B9B9;            /* 文字色 */
+  font-size: 20px;
+  /* フォントサイズ */
+  margin-bottom: 20px;
+  /* 下にスペース */
+  margin-left: 80px;
+  color: #B9B9B9;
+  /* 文字色 */
+}
+
+/* ポップアップ */
+
+.popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 9999;
+  background-color: rgba(0, 0, 0, 0.5);
+  /* 背景の暗がり */
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.popup-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 10px;
+  width: 300px;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 20px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.close-btn:hover {
+  color: red;
+}
+
+/* 編集ボタン・削除ボタンのCSS */
+.icon-button {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.icon-image {
+  width: 24px;
+  height: 24px;
 }

--- a/src/main/resources/static/css/book/index.css
+++ b/src/main/resources/static/css/book/index.css
@@ -140,7 +140,6 @@
 }
 
 /* ポップアップ */
-
 .popup {
   position: fixed;
   top: 50%;

--- a/src/main/resources/static/js/book/edit.js
+++ b/src/main/resources/static/js/book/edit.js
@@ -1,0 +1,6 @@
+function closePopup() {
+  const popup = document.querySelector('.popup');
+  if (popup) {
+    popup.style.display = 'none';
+  }
+}

--- a/src/main/resources/static/js/book/index.js
+++ b/src/main/resources/static/js/book/index.js
@@ -1,0 +1,13 @@
+function closePopup() {
+  // ID が customPopup のポップアップを閉じる
+  const customPopup = document.getElementById("customPopup");
+  if (customPopup) {
+    customPopup.style.display = "none";
+  }
+
+  // クラス名が popup のポップアップを閉じる（汎用）
+  const classPopup = document.querySelector(".popup");
+  if (classPopup) {
+    classPopup.style.display = "none";
+  }
+}

--- a/src/main/resources/templates/book/edit.html
+++ b/src/main/resources/templates/book/edit.html
@@ -69,7 +69,7 @@
 <div class="popup" th:if="${noChangeMessage}">
   <div class="popup-content">
     <span class="close-btn" onclick="closePopup()">&times;</span>
-    <p th:text="${noChangeMessage}">変更点はありません</p>
+    <p th:text="${noChangeMessage}"></p>
   </div>
 </div>
 

--- a/src/main/resources/templates/book/edit.html
+++ b/src/main/resources/templates/book/edit.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{common :: meta_header('書籍編集',~{::link},~{::script})}">
+    <title th:text="${title}+' | MTLibrary'"></title>
+    <link rel="stylesheet" th:href="@{/css/book/edit.css}" />
+    <script type="text/javascript" th:src="@{/js/book/edit.js}"></script>
+</head>
+
+<body>
+    <div class="contents">
+        <div th:replace="~{common :: main_sidebar}"></div>
+        <div class="main_contents">
+            <div th:replace="~{common :: header}"></div>
+            <div class="inner_contens">
+                <div class="page_title">書籍編集</div>
+                <div class="page_contents">
+                    <td><span class="required-info">＊は必須項目です</span></td>
+                    <div class="mb30 flexarea">
+                        <span class="back-link">
+                            <a th:href="@{/book/index}" class="link">← 一覧へ戻る</a>
+                        </span>
+                    </div>
+                    <form id="book_register_form" th:object="${bookMstDto}" th:action="@{/book/edit}" method="post">
+                        <input type="hidden" th:field="*{id}" th:name="${_csrf.parameterName}"
+                            th:value="${_csrf.token}" />
+
+                        <!-- 書籍名 -->
+                        <div class="form-group">
+                            <div class="label-error-row">
+                                <label for="title">書籍名<span class="required-info">*</span></label>
+                                <div class="inline-error" th:if="${titleErrors}">
+                                    <span th:each="error : ${titleErrors}" th:text="${error}"
+                                        class="error-message"></span>
+                                </div>
+                            </div>
+                            <input type="text" id="title" placeholder="書籍名を入力" th:field="*{title}"
+                                th:attr="data-original-title=${bookMstDto.title}" />
+
+                        </div>
+
+                        <!-- ISBN -->
+                        <div class="form-group">
+                            <div class="label-error-row">
+                                <label for="isbn">ISBN<span class="required-info">*</span></label>
+                                <div class="inline-error" th:if="${isbnErrors}">
+                                    <span th:each="error : ${isbnErrors}" th:text="${error}"
+                                        class="error-message"></span>
+                                </div>
+                            </div>
+                            <input type="text" id="isbn" placeholder="ISBNを入力" th:field="*{isbn}"
+                                th:attr="data-original-isbn=${bookMstDto.isbn}" />
+                        </div>
+
+                        <!-- 更新ボタン -->
+                        <div class="btn_block">
+                            <button type="submit" id="submit_btn">更新</button>
+                        </div>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+    <div th:replace="~{common :: footer}"></div>
+</body>
+
+<!-- ポップアップ -->
+<div class="popup" th:if="${noChangeMessage}">
+  <div class="popup-content">
+    <span class="close-btn" onclick="closePopup()">&times;</span>
+    <p th:text="${noChangeMessage}">変更点はありません</p>
+  </div>
+</div>
+
+<script th:src="@{/js/edit.js}"></script>

--- a/src/main/resources/templates/book/index.html
+++ b/src/main/resources/templates/book/index.html
@@ -70,7 +70,6 @@
                         </div>
                     </div>
 
-
                     <!-- 外部JS -->
                     <script th:src="@{/js/index.js}"></script>
                     

--- a/src/main/resources/templates/book/index.html
+++ b/src/main/resources/templates/book/index.html
@@ -14,32 +14,66 @@
             <div th:replace="~{common :: header}"></div>
             <div class="inner_contens">
                 <div class="page_title">書籍一覧</div>
+                <!-- 書籍登録のボタン -->
                 <div class="btn_block">
-                    <div style="text-align: right;">
-                        <form th:action="@{/book/add}" method="get" style="display: inline-block;">
-                            <input type="submit" value="➕📚 書籍登録"
-                                style="padding: 12px 24px; font-size: 16px; background-color: #87f4b4fa;border: 1px solid #87f4b4fa;">
-                        </form>
-                    </div>
+                    <a th:href="@{/book/add}" method="get" class="add-book-form">
+                        <button type="submit" class="add-book-btn">
+                            <img th:src="@{/images/icons/add.png}" alt="追加" class="icon-image">
+                            書籍登録
+                        </button>
+                    </a>
                 </div>
-                    <!-- 書籍一覧のタイトル -->
-                    <div class="table_title">書籍一覧</div>
+                <!-- 書籍一覧のタイトル -->
+                <div class="table_title">書籍一覧</div>
 
                 <table class="book_table" border="1" style="margin-left: 80px;">
                     <thead>
                         <tr>
                             <th>書籍名</th>
                             <th>ISBN</th>
+                            <th>利用可能在庫数</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr th:each="book : ${bookMstList}">
                             <td>
+                                <!-- 編集ボタン -->
+                                <a th:href="@{/book/edit/{id}(id=${book.id})}" class="icon-button">
+                                    <img th:src="@{/images/icons/edit.png}" alt="編集" class="icon-button">
+                                </a>
+                                <!-- 削除ボタン -->
+                                <a th:href="@{/book/delete/{id}(id=${book.id})}" class="icon-button"
+                                    onclick="return confirm('本当に削除しますか？');">
+                                    <img th:src="@{/images/icons/trash.png}" alt="削除" class="icon-button">
+                                </a>
+
                                 <div class="wrap-title" th:text="${book.title}"></div>
                             </td>
                             <td th:text="${book.isbn}"></td>
+                            </td>
+                            <!-- ここに利用可能在庫数入れるはず -->
+                            <td>
                         </tr>
                     </tbody>
+
+                    <div class="popup" th:if="${deleteMessage}">
+                        <div class="popup-content">
+                            <span class="close-btn" onclick="closePopup()">&times;</span>
+                            <p th:text="${deleteMessage}">書籍はすでに削除されています。</p>
+                        </div>
+                    </div>
+
+                    <div id="customPopup" class="popup" th:if="${errorMessage}">
+                        <div class="popup-content">
+                            <span class="close-btn" onclick="closePopup()">&times;</span>
+                            <p th:text="${errorMessage}"></p>
+                        </div>
+                    </div>
+
+
+                    <!-- 外部JS -->
+                    <script th:src="@{/js/index.js}"></script>
+                    
                 </table>
                 <div th:replace="~{common :: footer}"></div>
             </div>


### PR DESCRIPTION

![FireShot Capture 033 - 書籍編集 - MTLibrary -  localhost](https://github.com/user-attachments/assets/5318bb0e-fc05-4767-9c62-aad847a94883)
![FireShot Capture 032 - 書籍編集 - MTLibrary -  localhost](https://github.com/user-attachments/assets/0a5e6e51-d621-4e1e-95b3-5e5844c57761)
![FireShot Capture 031 - 書籍一覧 - MTLibrary -  localhost](https://github.com/user-attachments/assets/3ee8b44a-4de9-4a6b-b765-c6a19b182835)
【変更点】
書籍一覧画面変更点
・書籍登録ボタンのレイアウト変更
・編集アイコン・（削除アイコン）の追加→編集アイコンから編集画面への遷移
・利用可能在庫数枠の追加（内容には変化なし）
・エラーポップアップ表示（書籍が削除されていた場合に編集ボタンをクリックする）

書籍編集画面
・IDを紐づけし、同IDのtitleとisbnをテキストボックスに追加
・テキストボックス内のバリデーションチェック・重複チェック
・更新ボタン押したときのデータ更新
・エラーポップアップ表示（変更点なしの場合、エラーメッセージを表示）
・エラーポップアップ表示（編集画面の時に第三者により書籍データが削除された場合、一覧画面に遷移して表示）

【未対応】 
・完了ポップアップの表示（DBに問題なく変更できた際）⇒一覧画面にリダイレクト
・DBへの削除機能（delete）